### PR TITLE
fix: build command was excluded from backups

### DIFF
--- a/.projects/lib/utils.sh
+++ b/.projects/lib/utils.sh
@@ -71,8 +71,10 @@ __tar()
         --exclude='.mypy_cache' \
         --exclude='Debug' \
         --exclude='Release' \
+        --exclude='debug' \
+        --exclude='release' \
         --exclude='__pycache__' \
-        --exclude='build' \
+        --exclude='**/build/*' # Exclude content of `build` folder, not `build` as a file \
         --exclude='coverage' \
         --exclude='cscope.*' \
         --exclude='doxygen' \


### PR DESCRIPTION
`build` is excluded from the backups (`tar`) this is applicable to folders and files.
`build` is often used as command in my projects. The `build` folder contains temporary files for creating an executable.
Changed exclusion to exclude all contents in a `build` folder, it does not exclude `build` as a file/command.