### PR TITLE
Fix: Moved comment out of a multiline command which broke the backup …

### DIFF
--- a/.projects/lib/utils.sh
+++ b/.projects/lib/utils.sh
@@ -62,6 +62,8 @@ __list_options()
 
 __tar()
 {
+    # Fix: Exclude content of `build` folder, not `build` as a file/command and folder.
+
     local archive="${1}"
     local folder="${2}"
     local name="${3}"
@@ -74,7 +76,7 @@ __tar()
         --exclude='debug' \
         --exclude='release' \
         --exclude='__pycache__' \
-        --exclude='**/build/*' # Exclude content of `build` folder, not `build` as a file \
+        --exclude='**/build/*' \
         --exclude='coverage' \
         --exclude='cscope.*' \
         --exclude='doxygen' \


### PR DESCRIPTION
Moved comment in `__tar` function outside of the multi-line `tar` command.
Fixed error `tar: Cowardly refusing to create an empty archive`